### PR TITLE
feat: Ignore comment lines starting with %

### DIFF
--- a/src/my_cli_tool/main.py
+++ b/src/my_cli_tool/main.py
@@ -174,6 +174,8 @@ def append_file_content(filepath, doc):
                     continue # Skip empty lines between paragraphs
                 if re.match(r'^#{1,6}\s', para_text):
                     continue # Skip markdown headings
+                if para_text.startswith('%'):
+                    continue # Skip comment lines
 
                 p = doc.add_paragraph()
                 # Set standard manuscript formatting


### PR DESCRIPTION
This commit introduces a new feature that allows the formatter to ignore any line beginning with a leading '%' character. This is useful for adding comments or notes within the manuscript source files that should not be included in the final compiled output.

The change is implemented in the `append_file_content` function by adding a condition that checks if a stripped line starts with '%' and, if so, skips it.